### PR TITLE
Fix XHP multi-comment recognition

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1020,7 +1020,9 @@ const rules = {
       ),
     ),
 
-  xhp_string: $ => /[^<]+/,
+  xhp_comment: $ => token(seq('<!--', /(-?>)?([^>]|[^-]>|[^-]->)*/, '-->')),
+
+  xhp_string: $ => /[^<{]+/,
 
   xhp_open: $ => seq('<', $.xhp_identifier, rep($.xhp_attribute), '>'),
 
@@ -1136,7 +1138,7 @@ module.exports = grammar({
 
   extras: $ => [/\s/, $.comment],
 
-  externals: $ => [$._heredoc_start, $._heredoc_body, $._heredoc_end, $.xhp_comment],
+  externals: $ => [$._heredoc_start, $._heredoc_body, $._heredoc_end],
 
   supertypes: $ => [
     $._statement,

--- a/grammar.js
+++ b/grammar.js
@@ -1020,8 +1020,6 @@ const rules = {
       ),
     ),
 
-  xhp_comment: $ => /<!--(.|[\n\r])*-->/,
-
   xhp_string: $ => /[^<]+/,
 
   xhp_open: $ => seq('<', $.xhp_identifier, rep($.xhp_attribute), '>'),
@@ -1138,7 +1136,7 @@ module.exports = grammar({
 
   extras: $ => [/\s/, $.comment],
 
-  externals: $ => [$._heredoc_start, $._heredoc_body, $._heredoc_end],
+  externals: $ => [$._heredoc_start, $._heredoc_body, $._heredoc_end, $.xhp_comment],
 
   supertypes: $ => [
     $._statement,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -7344,12 +7344,28 @@
       ]
     },
     "xhp_comment": {
-      "type": "PATTERN",
-      "value": "<!--(.|[\\n\\r])*-->"
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "<!--"
+          },
+          {
+            "type": "PATTERN",
+            "value": "(-?>)?([^>]|[^-]>|[^-]->)*"
+          },
+          {
+            "type": "STRING",
+            "value": "-->"
+          }
+        ]
+      }
     },
     "xhp_string": {
       "type": "PATTERN",
-      "value": "[^<]+"
+      "value": "[^<{]+"
     },
     "xhp_open": {
       "type": "SEQ",

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -41,10 +41,9 @@ enum TokenType {
   HEREDOC_START,
   HEREDOC_BODY,
   HEREDOC_END,
-  XHP_COMMENT,
 };
 
-const char *TokenTypes[] = {"HEREDOC_START", "HEREDOC_BODY", "HEREDOC_END", "XHP_COMMENT"};
+const char *TokenTypes[] = {"HEREDOC_START", "HEREDOC_BODY", "HEREDOC_END"};
 
 static const char *str(int32_t chr) {
   switch (chr) {
@@ -126,16 +125,6 @@ struct Scanner {
         set(HEREDOC_START);
         return true;
       }
-    }
-
-    if (expected[XHP_COMMENT] && peek() == '<') {
-        stop();
-        next();
-
-        if (peek() == '!') {
-          next();
-          return scan_comment(lexer);
-        }
     }
 
     return false;
@@ -280,33 +269,6 @@ struct Scanner {
         }
       }
     }
-  }
-
-  bool scan_comment(TSLexer *lexer) {
-    if (peek() != '-') return false;
-    next();
-    if (peek() != '-') return false;
-    next();
-
-    unsigned dashes = 0;
-    while (peek()) {
-      switch (peek()) {
-        case '-':
-          ++dashes;
-          break;
-        case '>':
-          if (dashes >= 2) {
-            set(XHP_COMMENT);
-            next();
-            stop();
-            return true;
-          }
-        default:
-          dashes = 0;
-      }
-      next();
-    }
-    return false;
   }
 
   string delimiter;

--- a/test/cases/expressions/xhp-brace.exp
+++ b/test/cases/expressions/xhp-brace.exp
@@ -1,0 +1,19 @@
+(script
+  (return_statement
+    (xhp_expression
+      (xhp_open
+        (xhp_identifier))
+      (xhp_string)
+      (xhp_braced_expression
+        (variable))
+      (xhp_string)
+      (xhp_braced_expression
+        (call_expression
+          function: (selection_expression
+            (variable)
+            (qualified_identifier
+              (identifier)))
+          (arguments)))
+      (xhp_string)
+      (xhp_close
+        (xhp_identifier)))))

--- a/test/cases/expressions/xhp-brace.hack
+++ b/test/cases/expressions/xhp-brace.hack
@@ -1,0 +1,3 @@
+return <frag>
+    Hi! {$this} is a {$this->test()}!
+</frag>;

--- a/test/cases/expressions/xhp-comment.exp
+++ b/test/cases/expressions/xhp-comment.exp
@@ -1,0 +1,12 @@
+(script
+  (return_statement
+    (xhp_expression
+      (xhp_open
+        (xhp_identifier))
+      (xhp_string)
+      (xhp_comment)
+      (xhp_string)
+      (xhp_comment)
+      (xhp_string)
+      (xhp_close
+        (xhp_identifier)))))

--- a/test/cases/expressions/xhp-comment.exp
+++ b/test/cases/expressions/xhp-comment.exp
@@ -6,6 +6,9 @@
       (xhp_string)
       (xhp_comment)
       (xhp_string)
+      (xhp_braced_expression
+        (variable))
+      (xhp_string)
       (xhp_comment)
       (xhp_string)
       (xhp_close

--- a/test/cases/expressions/xhp-comment.hack
+++ b/test/cases/expressions/xhp-comment.hack
@@ -1,6 +1,6 @@
 return <frag>
-    <!--  comment
+    <!--  co--mm->e>nt
     one  -->
-    {$this->test()}
+    Te{$this}st
     <!--  comment two  -->
 </frag>;

--- a/test/cases/expressions/xhp-comment.hack
+++ b/test/cases/expressions/xhp-comment.hack
@@ -1,0 +1,6 @@
+return <frag>
+    <!--  comment
+    one  -->
+    {$this->test()}
+    <!--  comment two  -->
+</frag>;


### PR DESCRIPTION
Fixes cases where there are multiple comments in an XHP expression. It did not error before, but recognized everything between the first and last comment as one XHP comment.

I tried many different patterns to write this rule natively in `grammar.js`, but tree-sitter seems to only support this functionality through an external scanner.

AFAIK, there is no serializable state management necessary because comments are indivisible.


**Previous** test output on `main`:
```
(script [0, 0] - [5, 8]
  (return_statement [0, 0] - [5, 8]
    (xhp_expression [0, 7] - [5, 7]
      (xhp_open [0, 7] - [0, 13]
        (xhp_identifier [0, 8] - [0, 12]))
      (xhp_string [0, 13] - [1, 4])
      (xhp_comment [1, 4] - [4, 26]) #This is incorrect
      (xhp_string [4, 26] - [5, 0])
      (xhp_close [5, 0] - [5, 7]
        (xhp_identifier [5, 2] - [5, 6])))))
```