### PR TITLE
Support keyword and brace selection expression

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -177,6 +177,8 @@ const rules = {
       ),
     ),
 
+  braced_expression: $ => seq('{', $._expression, '}'),
+
   _expression: $ =>
     choice(
       $.heredoc,
@@ -725,7 +727,7 @@ const rules = {
       seq(
         $._variablish,
         field('selection_operator', choice('?->', '->')),
-        choice($._variablish, $.embedded_brace_expression, alias($._keyword, $.identifier)),
+        choice($._variablish, $.braced_expression, alias($._keyword, $.identifier)),
       ),
     ),
 
@@ -1015,7 +1017,7 @@ const rules = {
           choice(
             $.xhp_string,
             $.xhp_comment,
-            $.xhp_braced_expression,
+            $.braced_expression,
             $.xhp_expression,
           ),
         ),
@@ -1035,11 +1037,9 @@ const rules = {
 
   xhp_attribute: $ =>
     choice(
-      seq($.xhp_identifier, '=', choice($.string, $.xhp_braced_expression)),
-      choice($.xhp_braced_expression, $.xhp_spread_expression),
+      seq($.xhp_identifier, '=', choice($.string, $.braced_expression)),
+      choice($.braced_expression, $.xhp_spread_expression),
     ),
-
-  xhp_braced_expression: $ => seq('{', $._expression, '}'),
 
   xhp_spread_expression: $ => seq('{', '...', $._expression, '}'),
 

--- a/grammar.js
+++ b/grammar.js
@@ -57,6 +57,9 @@ const rules = {
       'newtype',
       'shape',
       'tupe',
+      'clone',
+      'new',
+      'print',
       $._primitive_type,
       $._collection_type,
     ),
@@ -722,7 +725,7 @@ const rules = {
       seq(
         $._variablish,
         field('selection_operator', choice('?->', '->')),
-        $._variablish,
+        choice($._variablish, $.embedded_brace_expression, alias($._keyword, $.identifier)),
       ),
     ),
 
@@ -1158,6 +1161,7 @@ module.exports = grammar({
     $._primitive_type,
     $._collection_type,
     $._xhp_attribute_expression,
+    $._keyword,
   ],
 
   conflicts: $ => [

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -70,6 +70,18 @@
           "value": "tupe"
         },
         {
+          "type": "STRING",
+          "value": "clone"
+        },
+        {
+          "type": "STRING",
+          "value": "new"
+        },
+        {
+          "type": "STRING",
+          "value": "print"
+        },
+        {
           "type": "SYMBOL",
           "name": "_primitive_type"
         },
@@ -5396,8 +5408,26 @@
             }
           },
           {
-            "type": "SYMBOL",
-            "name": "_variablish"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_variablish"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "embedded_brace_expression"
+              },
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_keyword"
+                },
+                "named": true,
+                "value": "identifier"
+              }
+            ]
           }
         ]
       }
@@ -8176,7 +8206,8 @@
     "_type",
     "_primitive_type",
     "_collection_type",
-    "_xhp_attribute_expression"
+    "_xhp_attribute_expression",
+    "_keyword"
   ],
   "supertypes": [
     "_statement",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -559,6 +559,23 @@
         ]
       }
     },
+    "braced_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expression"
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
     "_expression": {
       "type": "CHOICE",
       "members": [
@@ -5416,7 +5433,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "embedded_brace_expression"
+                "name": "braced_expression"
               },
               {
                 "type": "ALIAS",
@@ -7356,7 +7373,7 @@
                   },
                   {
                     "type": "SYMBOL",
-                    "name": "xhp_braced_expression"
+                    "name": "braced_expression"
                   },
                   {
                     "type": "SYMBOL",
@@ -7485,7 +7502,7 @@
                 },
                 {
                   "type": "SYMBOL",
-                  "name": "xhp_braced_expression"
+                  "name": "braced_expression"
                 }
               ]
             }
@@ -7496,30 +7513,13 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "xhp_braced_expression"
+              "name": "braced_expression"
             },
             {
               "type": "SYMBOL",
               "name": "xhp_spread_expression"
             }
           ]
-        }
-      ]
-    },
-    "xhp_braced_expression": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "{"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_expression"
-        },
-        {
-          "type": "STRING",
-          "value": "}"
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -765,6 +765,21 @@
     }
   },
   {
+    "type": "braced_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "break_statement",
     "named": true,
     "fields": {},
@@ -2561,11 +2576,11 @@
       "required": true,
       "types": [
         {
-          "type": "call_expression",
+          "type": "braced_expression",
           "named": true
         },
         {
-          "type": "embedded_brace_expression",
+          "type": "call_expression",
           "named": true
         },
         {
@@ -3493,11 +3508,11 @@
       "required": true,
       "types": [
         {
-          "type": "string",
+          "type": "braced_expression",
           "named": true
         },
         {
-          "type": "xhp_braced_expression",
+          "type": "string",
           "named": true
         },
         {
@@ -3521,21 +3536,6 @@
       "types": [
         {
           "type": "xhp_class_attribute",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "xhp_braced_expression",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "_expression",
           "named": true
         }
       ]
@@ -3674,7 +3674,7 @@
       "required": true,
       "types": [
         {
-          "type": "xhp_braced_expression",
+          "type": "braced_expression",
           "named": true
         },
         {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1691,21 +1691,6 @@
     }
   },
   {
-    "type": "identifier",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": false,
-      "types": [
-        {
-          "type": "null",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
     "type": "if_statement",
     "named": true,
     "fields": {
@@ -2577,6 +2562,14 @@
       "types": [
         {
           "type": "call_expression",
+          "named": true
+        },
+        {
+          "type": "embedded_brace_expression",
+          "named": true
+        },
+        {
+          "type": "identifier",
           "named": true
         },
         {
@@ -4204,6 +4197,10 @@
     "named": false
   },
   {
+    "type": "identifier",
+    "named": true
+  },
+  {
     "type": "if",
     "named": false
   },
@@ -4353,11 +4350,11 @@
   },
   {
     "type": "string",
-    "named": true
+    "named": false
   },
   {
     "type": "string",
-    "named": false
+    "named": true
   },
   {
     "type": "super",

--- a/test/cases/declarations/const-keyword.exp
+++ b/test/cases/declarations/const-keyword.exp
@@ -44,8 +44,7 @@
       value: (integer)))
   (const_declaration
     (const_declarator
-      name: (identifier
-        (null))
+      name: (identifier)
       value: (integer)))
   (const_declaration
     (const_declarator

--- a/test/cases/expressions/selection-brace.exp
+++ b/test/cases/expressions/selection-brace.exp
@@ -2,26 +2,36 @@
   (expression_statement
     (selection_expression
       (variable)
-      (embedded_brace_expression
+      (braced_expression
         (variable))))
+  (expression_statement
+    (selection_expression
+      (variable)
+      (braced_expression
+        (call_expression
+          function: (selection_expression
+            (variable)
+            (qualified_identifier
+              (identifier)))
+          (arguments)))))
   (expression_statement
     (selection_expression
       (selection_expression
         (selection_expression
           (variable)
-          (embedded_brace_expression
+          (braced_expression
             (variable)))
-        (embedded_brace_expression
+        (braced_expression
           (variable)))
-      (embedded_brace_expression
+      (braced_expression
         (variable))))
   (expression_statement
     (selection_expression
       (selection_expression
         (selection_expression
           (variable)
-          (embedded_brace_expression
+          (braced_expression
             (variable)))
         (variable))
-      (embedded_brace_expression
+      (braced_expression
         (variable)))))

--- a/test/cases/expressions/selection-brace.exp
+++ b/test/cases/expressions/selection-brace.exp
@@ -1,0 +1,27 @@
+(script
+  (expression_statement
+    (selection_expression
+      (variable)
+      (embedded_brace_expression
+        (variable))))
+  (expression_statement
+    (selection_expression
+      (selection_expression
+        (selection_expression
+          (variable)
+          (embedded_brace_expression
+            (variable)))
+        (embedded_brace_expression
+          (variable)))
+      (embedded_brace_expression
+        (variable))))
+  (expression_statement
+    (selection_expression
+      (selection_expression
+        (selection_expression
+          (variable)
+          (embedded_brace_expression
+            (variable)))
+        (variable))
+      (embedded_brace_expression
+        (variable)))))

--- a/test/cases/expressions/selection-brace.hack
+++ b/test/cases/expressions/selection-brace.hack
@@ -1,5 +1,7 @@
 $dynamic_item->{$primary_key};
 
+$dynamic_item->{$fun->test()};
+
 $dynamic_item->{$primary_key}->{$primary_key2}->{$primary_key3};
 
 $dynamic_item->{$primary_key}->$primary_key2->{$primary_key3};

--- a/test/cases/expressions/selection-brace.hack
+++ b/test/cases/expressions/selection-brace.hack
@@ -1,0 +1,5 @@
+$dynamic_item->{$primary_key};
+
+$dynamic_item->{$primary_key}->{$primary_key2}->{$primary_key3};
+
+$dynamic_item->{$primary_key}->$primary_key2->{$primary_key3};

--- a/test/cases/expressions/selection-with-keyword.exp
+++ b/test/cases/expressions/selection-with-keyword.exp
@@ -1,0 +1,35 @@
+(script
+  (expression_statement
+    (call_expression
+      function: (selection_expression
+        (variable)
+        (identifier))
+      (arguments)))
+  (expression_statement
+    (call_expression
+      function: (selection_expression
+        (variable)
+        (identifier))
+      (arguments)))
+  (expression_statement
+    (call_expression
+      function: (selection_expression
+        (variable)
+        (identifier))
+      (arguments)))
+  (expression_statement
+    (selection_expression
+      (call_expression
+        function: (selection_expression
+          (call_expression
+            function: (selection_expression
+              (call_expression
+                function: (selection_expression
+                  (variable)
+                  (identifier))
+                (arguments))
+              (identifier))
+            (arguments))
+          (identifier))
+        (arguments))
+      (variable))))

--- a/test/cases/expressions/selection-with-keyword.hack
+++ b/test/cases/expressions/selection-with-keyword.hack
@@ -1,0 +1,7 @@
+$this->clone();
+
+$this->print();
+
+$this->new();
+
+$this->clone()->new()->print()->$item;

--- a/test/cases/expressions/xhp-brace.exp
+++ b/test/cases/expressions/xhp-brace.exp
@@ -4,10 +4,10 @@
       (xhp_open
         (xhp_identifier))
       (xhp_string)
-      (xhp_braced_expression
+      (braced_expression
         (variable))
       (xhp_string)
-      (xhp_braced_expression
+      (braced_expression
         (call_expression
           function: (selection_expression
             (variable)

--- a/test/cases/expressions/xhp-comment.exp
+++ b/test/cases/expressions/xhp-comment.exp
@@ -6,7 +6,7 @@
       (xhp_string)
       (xhp_comment)
       (xhp_string)
-      (xhp_braced_expression
+      (braced_expression
         (variable))
       (xhp_string)
       (xhp_comment)


### PR DESCRIPTION
Adds support for keywords and braces in selection expressions. Includes tests as well. 

Somehow also indirectly repaired `const-keyword.exp`, which I believe incorrectly had a `null`.

I didn't see any other types that the brace expression would be better nested under but if I missed something there LMK.