### PR TITLE
Allow both XHP syntax versions as tags

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -78,8 +78,7 @@ const rules = {
         $.qualified_identifier,
         $.variable,
         $.scope_identifier,
-        $.xhp_identifier,
-        $.xhp_class_identifier,
+        $._xhp_identifiers,
         $.pipe_variable,
       ),
       '::',
@@ -100,8 +99,7 @@ const rules = {
       $.scoped_identifier,
       $.scope_identifier,
       $.selection_expression,
-      $.xhp_identifier,
-      $.xhp_class_identifier,
+      $._xhp_identifiers,
     ),
 
   _statement: $ =>
@@ -432,8 +430,7 @@ const rules = {
         $._primitive_type,
         $.qualified_identifier,
         $._collection_type,
-        $.xhp_identifier,
-        $.xhp_class_identifier,
+        $._xhp_identifiers,
       ),
       opt($.type_arguments),
     ),
@@ -808,7 +805,7 @@ const rules = {
       opt($._class_modifier),
       opt($.xhp_modifier),
       'class',
-      field('name', choice($.identifier, $.xhp_identifier, $.xhp_class_identifier)),
+      field('name', choice($.identifier, $._xhp_identifiers)),
       opt($.type_parameters),
       opt($.extends_clause),
       opt($.implements_clause),
@@ -1006,6 +1003,8 @@ const rules = {
 
   xhp_class_identifier: $ => /:[a-zA-Z_][a-zA-Z0-9_]*([-:][a-zA-Z0-9_]+)*/,
 
+  _xhp_identifiers: $ => choice($.xhp_identifier, $.xhp_class_identifier),
+
   xhp_category_identifier: $ => /%[a-zA-Z_][a-zA-Z0-9_]*([-:][a-zA-Z0-9_]+)*/,
 
   xhp_expression: $ =>
@@ -1029,11 +1028,11 @@ const rules = {
 
   xhp_string: $ => token(prec(1, /[^<{]+/)),
 
-  xhp_open: $ => seq('<', $.xhp_identifier, rep($.xhp_attribute), '>'),
+  xhp_open: $ => seq('<', $._xhp_identifiers, rep($.xhp_attribute), '>'),
 
-  xhp_open_close: $ => seq('<', $.xhp_identifier, rep($.xhp_attribute), '/>'),
+  xhp_open_close: $ => seq('<', $._xhp_identifiers, rep($.xhp_attribute), '/>'),
 
-  xhp_close: $ => seq('</', $.xhp_identifier, '>'),
+  xhp_close: $ => seq('</', $._xhp_identifiers, '>'),
 
   xhp_attribute: $ =>
     choice(

--- a/grammar.js
+++ b/grammar.js
@@ -78,7 +78,7 @@ const rules = {
         $.qualified_identifier,
         $.variable,
         $.scope_identifier,
-        $._xhp_identifiers,
+        $._xhp_identifier,
         $.pipe_variable,
       ),
       '::',
@@ -99,7 +99,7 @@ const rules = {
       $.scoped_identifier,
       $.scope_identifier,
       $.selection_expression,
-      $._xhp_identifiers,
+      $._xhp_identifier,
     ),
 
   _statement: $ =>
@@ -430,7 +430,7 @@ const rules = {
         $._primitive_type,
         $.qualified_identifier,
         $._collection_type,
-        $._xhp_identifiers,
+        $._xhp_identifier,
       ),
       opt($.type_arguments),
     ),
@@ -805,7 +805,7 @@ const rules = {
       opt($._class_modifier),
       opt($.xhp_modifier),
       'class',
-      field('name', choice($.identifier, $._xhp_identifiers)),
+      field('name', choice($.identifier, $._xhp_identifier)),
       opt($.type_parameters),
       opt($.extends_clause),
       opt($.implements_clause),
@@ -1003,7 +1003,7 @@ const rules = {
 
   xhp_class_identifier: $ => /:[a-zA-Z_][a-zA-Z0-9_]*([-:][a-zA-Z0-9_]+)*/,
 
-  _xhp_identifiers: $ => choice($.xhp_identifier, $.xhp_class_identifier),
+  _xhp_identifier: $ => choice($.xhp_identifier, $.xhp_class_identifier),
 
   xhp_category_identifier: $ => /%[a-zA-Z_][a-zA-Z0-9_]*([-:][a-zA-Z0-9_]+)*/,
 
@@ -1028,11 +1028,11 @@ const rules = {
 
   xhp_string: $ => token(prec(1, /[^<{]+/)),
 
-  xhp_open: $ => seq('<', $._xhp_identifiers, rep($.xhp_attribute), '>'),
+  xhp_open: $ => seq('<', $._xhp_identifier, rep($.xhp_attribute), '>'),
 
-  xhp_open_close: $ => seq('<', $._xhp_identifiers, rep($.xhp_attribute), '/>'),
+  xhp_open_close: $ => seq('<', $._xhp_identifier, rep($.xhp_attribute), '/>'),
 
-  xhp_close: $ => seq('</', $._xhp_identifiers, '>'),
+  xhp_close: $ => seq('</', $._xhp_identifier, '>'),
 
   xhp_attribute: $ =>
     choice(
@@ -1161,6 +1161,7 @@ module.exports = grammar({
     $._collection_type,
     $._xhp_attribute_expression,
     $._keyword,
+    $._xhp_identifier,
   ],
 
   conflicts: $ => [

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -157,11 +157,7 @@
             },
             {
               "type": "SYMBOL",
-              "name": "xhp_identifier"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "xhp_class_identifier"
+              "name": "_xhp_identifiers"
             },
             {
               "type": "SYMBOL",
@@ -250,11 +246,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "xhp_identifier"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "xhp_class_identifier"
+          "name": "_xhp_identifiers"
         }
       ]
     },
@@ -1995,11 +1987,7 @@
             },
             {
               "type": "SYMBOL",
-              "name": "xhp_identifier"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "xhp_class_identifier"
+              "name": "_xhp_identifiers"
             }
           ]
         },
@@ -6059,11 +6047,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "xhp_identifier"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "xhp_class_identifier"
+                "name": "_xhp_identifiers"
               }
             ]
           }
@@ -7349,6 +7333,19 @@
       "type": "PATTERN",
       "value": ":[a-zA-Z_][a-zA-Z0-9_]*([-:][a-zA-Z0-9_]+)*"
     },
+    "_xhp_identifiers": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "xhp_identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "xhp_class_identifier"
+        }
+      ]
+    },
     "xhp_category_identifier": {
       "type": "PATTERN",
       "value": "%[a-zA-Z_][a-zA-Z0-9_]*([-:][a-zA-Z0-9_]+)*"
@@ -7439,7 +7436,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "xhp_identifier"
+          "name": "_xhp_identifiers"
         },
         {
           "type": "REPEAT",
@@ -7463,7 +7460,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "xhp_identifier"
+          "name": "_xhp_identifiers"
         },
         {
           "type": "REPEAT",
@@ -7487,7 +7484,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "xhp_identifier"
+          "name": "_xhp_identifiers"
         },
         {
           "type": "STRING",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -157,7 +157,7 @@
             },
             {
               "type": "SYMBOL",
-              "name": "_xhp_identifiers"
+              "name": "_xhp_identifier"
             },
             {
               "type": "SYMBOL",
@@ -246,7 +246,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_xhp_identifiers"
+          "name": "_xhp_identifier"
         }
       ]
     },
@@ -1987,7 +1987,7 @@
             },
             {
               "type": "SYMBOL",
-              "name": "_xhp_identifiers"
+              "name": "_xhp_identifier"
             }
           ]
         },
@@ -6047,7 +6047,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "_xhp_identifiers"
+                "name": "_xhp_identifier"
               }
             ]
           }
@@ -7333,7 +7333,7 @@
       "type": "PATTERN",
       "value": ":[a-zA-Z_][a-zA-Z0-9_]*([-:][a-zA-Z0-9_]+)*"
     },
-    "_xhp_identifiers": {
+    "_xhp_identifier": {
       "type": "CHOICE",
       "members": [
         {
@@ -7436,7 +7436,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_xhp_identifiers"
+          "name": "_xhp_identifier"
         },
         {
           "type": "REPEAT",
@@ -7460,7 +7460,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_xhp_identifiers"
+          "name": "_xhp_identifier"
         },
         {
           "type": "REPEAT",
@@ -7484,7 +7484,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_xhp_identifiers"
+          "name": "_xhp_identifier"
         },
         {
           "type": "STRING",
@@ -8220,7 +8220,8 @@
     "_primitive_type",
     "_collection_type",
     "_xhp_attribute_expression",
-    "_keyword"
+    "_keyword",
+    "_xhp_identifier"
   ],
   "supertypes": [
     "_statement",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3644,6 +3644,10 @@
       "required": true,
       "types": [
         {
+          "type": "xhp_class_identifier",
+          "named": true
+        },
+        {
           "type": "xhp_identifier",
           "named": true
         }
@@ -3721,6 +3725,10 @@
           "named": true
         },
         {
+          "type": "xhp_class_identifier",
+          "named": true
+        },
+        {
           "type": "xhp_identifier",
           "named": true
         }
@@ -3737,6 +3745,10 @@
       "types": [
         {
           "type": "xhp_attribute",
+          "named": true
+        },
+        {
+          "type": "xhp_class_identifier",
           "named": true
         },
         {

--- a/test/cases/expressions/xhp-as-arg-v3.exp
+++ b/test/cases/expressions/xhp-as-arg-v3.exp
@@ -1,0 +1,12 @@
+(script
+  (expression_statement
+    (call_expression
+      function: (scoped_identifier
+        (qualified_identifier
+          (identifier))
+        (identifier))
+      (arguments
+        (argument
+          (xhp_expression
+            (xhp_open_close
+              (xhp_class_identifier))))))))

--- a/test/cases/expressions/xhp-as-arg-v3.hack
+++ b/test/cases/expressions/xhp-as-arg-v3.hack
@@ -1,0 +1,1 @@
+TestXHP::display(<:page:subpage:test />);

--- a/test/cases/expressions/xhp-as-arg-v4.exp
+++ b/test/cases/expressions/xhp-as-arg-v4.exp
@@ -1,0 +1,12 @@
+(script
+  (expression_statement
+    (call_expression
+      function: (scoped_identifier
+        (qualified_identifier
+          (identifier))
+        (identifier))
+      (arguments
+        (argument
+          (xhp_expression
+            (xhp_open_close
+              (xhp_identifier))))))))

--- a/test/cases/expressions/xhp-as-arg-v4.hack
+++ b/test/cases/expressions/xhp-as-arg-v4.hack
@@ -1,0 +1,1 @@
+TestXHP::display(<page:subpage:test />);


### PR DESCRIPTION
- Refactor of our common v3/v4 double choice to a `_xhp_identifiers` option (hopefully not misleading that `xhp_category_identifier` isn't included)
    - Although did leave this reference as is for clarity: https://github.com/antoniodejesusochoasolano/tree-sitter-hack/blob/04b347918a53130564924d8018479afcdf46fd22/grammar.js#L1065-L1070
- Allows v3/v4 syntax in XHP tags (plus tests)

~While this does fix the error being tested for, it also _increases_ error count on real repos. I will want to investigate what's happening before merging.~ NA