### PR TITLE
Fix heredoc with no leading space parse bug

### DIFF
--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -213,7 +213,12 @@ struct Scanner {
 
     if (!is_nowdoc && prefix.empty()) {
       if (peek() == '{') next();
-      if (peek() == '$') return false;
+      if (peek() == '$') {
+        next();
+        if (is_identifier_start_char(peek())) {
+          return false;
+        }
+      }
     }
 
     for (;;) {

--- a/test/cases/literals/heredoc-dollar-embedded-var.exp
+++ b/test/cases/literals/heredoc-dollar-embedded-var.exp
@@ -1,6 +1,5 @@
 (script
   (comment) 
-  (comment) 
   (expression_statement
-    (heredoc)
-      variable )))
+    (heredoc
+      (variable))))

--- a/test/cases/literals/heredoc-dollar-embedded-var.hack
+++ b/test/cases/literals/heredoc-dollar-embedded-var.hack
@@ -1,5 +1,4 @@
 // This tests that the parser is correctly interprets when a variable is embedded between two string literals
-// This test currently fails but should pass
 
 <<<EOT
 	$()abc$()$realvar$()

--- a/test/cases/literals/heredoc-dollar-no-lead-space.exp
+++ b/test/cases/literals/heredoc-dollar-no-lead-space.exp
@@ -1,5 +1,3 @@
 (script
-  (comment)
   (expression_statement
-    (heredoc)
-      variable )))
+    (heredoc)))

--- a/test/cases/literals/heredoc-dollar-no-lead-space.hack
+++ b/test/cases/literals/heredoc-dollar-no-lead-space.hack
@@ -1,4 +1,3 @@
-// This test currently fails but should pass
 <<<EOT
 $()
 EOT;


### PR DESCRIPTION
# Description

Previously, the grammar could not parse heredocs if there were no leading spaces between a `$` and the beginning of a line in a heredoc. This is demonstrated in the following case:


Previously:
```
<<<EOT
$()                   <--- Parsing error
EOT;
```

This error was caused by the way the `$` was being processed and the parser incorrectly inferred that it was a start of a variable. Now the parser considers the following character before evaluating. In this case it sees `(` is not a valid identifier and therefore it must be part of the heredoc body.

Now:
```
<<<EOT
$()                   <--- Correctly interpreted as string literal
EOT;
```

# Testing

There were some modifications to test cases to update them with these changes. Originally, the expected output these two test cases were not properly written, so they are now correct. All test cases should pass now.

## Test steps:
1. Checkout `fix-heredoc-no-space-error`
2. Run `bin/test-corpus`
3. Ensure all tests pass

