### PR TITLE
Fix lambda arg parsing

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -448,9 +448,9 @@ const rules = {
   function_type_specifier: $ =>
     seq(
       rep($._type_modifier),
-      '(function(',
+      /\(\s*function\s*\(/,
       com.opt(opt($.inout_modifier), $._type, opt($.variadic_modifier), ','),
-      '):',
+      /\)\s*:/,
       field('return_type', $._type),
       ')',
     ),

--- a/grammar.js
+++ b/grammar.js
@@ -448,9 +448,11 @@ const rules = {
   function_type_specifier: $ =>
     seq(
       rep($._type_modifier),
-      /\(\s*function\s*\(/,
+      '(',
+      /function\s*\(/,
       com.opt(opt($.inout_modifier), $._type, opt($.variadic_modifier), ','),
-      /\)\s*:/,
+      ')',
+      ':',
       field('return_type', $._type),
       ')',
     ),

--- a/grammar.js
+++ b/grammar.js
@@ -448,12 +448,9 @@ const rules = {
   function_type_specifier: $ =>
     seq(
       rep($._type_modifier),
-      '(',
-      'function',
-      '(',
+      '(function(',
       com.opt(opt($.inout_modifier), $._type, opt($.variadic_modifier), ','),
-      ')',
-      ':',
+      '):',
       field('return_type', $._type),
       ')',
     ),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2106,15 +2106,7 @@
         },
         {
           "type": "STRING",
-          "value": "("
-        },
-        {
-          "type": "STRING",
-          "value": "function"
-        },
-        {
-          "type": "STRING",
-          "value": "("
+          "value": "(function("
         },
         {
           "type": "CHOICE",
@@ -2211,11 +2203,7 @@
         },
         {
           "type": "STRING",
-          "value": ")"
-        },
-        {
-          "type": "STRING",
-          "value": ":"
+          "value": "):"
         },
         {
           "type": "FIELD",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2105,8 +2105,8 @@
           }
         },
         {
-          "type": "STRING",
-          "value": "(function("
+          "type": "PATTERN",
+          "value": "\\(\\s*function\\s*\\("
         },
         {
           "type": "CHOICE",
@@ -2202,8 +2202,8 @@
           ]
         },
         {
-          "type": "STRING",
-          "value": "):"
+          "type": "PATTERN",
+          "value": "\\)\\s*:"
         },
         {
           "type": "FIELD",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2105,8 +2105,12 @@
           }
         },
         {
+          "type": "STRING",
+          "value": "("
+        },
+        {
           "type": "PATTERN",
-          "value": "\\(\\s*function\\s*\\("
+          "value": "function\\s*\\("
         },
         {
           "type": "CHOICE",
@@ -2202,8 +2206,12 @@
           ]
         },
         {
-          "type": "PATTERN",
-          "value": "\\)\\s*:"
+          "type": "STRING",
+          "value": ")"
+        },
+        {
+          "type": "STRING",
+          "value": ":"
         },
         {
           "type": "FIELD",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3829,7 +3829,15 @@
     "named": false
   },
   {
+    "type": "(function(",
+    "named": false
+  },
+  {
     "type": ")",
+    "named": false
+  },
+  {
+    "type": "):",
     "named": false
   },
   {
@@ -4194,11 +4202,11 @@
   },
   {
     "type": "float",
-    "named": true
+    "named": false
   },
   {
     "type": "float",
-    "named": false
+    "named": true
   },
   {
     "type": "for",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3829,15 +3829,7 @@
     "named": false
   },
   {
-    "type": "(function(",
-    "named": false
-  },
-  {
     "type": ")",
-    "named": false
-  },
-  {
-    "type": "):",
     "named": false
   },
   {
@@ -4202,11 +4194,11 @@
   },
   {
     "type": "float",
-    "named": false
+    "named": true
   },
   {
     "type": "float",
-    "named": true
+    "named": false
   },
   {
     "type": "for",

--- a/test/cases/expressions/lambda-with-lambda-arg.exp
+++ b/test/cases/expressions/lambda-with-lambda-arg.exp
@@ -13,7 +13,22 @@
       (parameters
         (parameter
           type: (function_type_specifier
+            (comment)
             return_type: (type_specifier))
           name: (variable)))
       return_type: (type_specifier)
-      body: (compound_statement))))
+      body: (compound_statement)))
+  (expression_statement
+    (lambda_expression
+      (parameters
+        (parameter
+          type: (function_type_specifier
+            (comment)
+            return_type: (type_specifier))
+          name: (variable)))
+      return_type: (type_specifier)
+      body: (compound_statement)))
+  (comment)
+  (comment)
+  (comment)
+  (comment))

--- a/test/cases/expressions/lambda-with-lambda-arg.exp
+++ b/test/cases/expressions/lambda-with-lambda-arg.exp
@@ -7,4 +7,13 @@
             return_type: (type_specifier))
           name: (variable)))
       return_type: (type_specifier)
+      body: (compound_statement)))
+  (expression_statement
+    (lambda_expression
+      (parameters
+        (parameter
+          type: (function_type_specifier
+            return_type: (type_specifier))
+          name: (variable)))
+      return_type: (type_specifier)
       body: (compound_statement))))

--- a/test/cases/expressions/lambda-with-lambda-arg.exp
+++ b/test/cases/expressions/lambda-with-lambda-arg.exp
@@ -1,0 +1,10 @@
+(script
+  (expression_statement
+    (lambda_expression
+      (parameters
+        (parameter
+          type: (function_type_specifier
+            return_type: (type_specifier))
+          name: (variable)))
+      return_type: (type_specifier)
+      body: (compound_statement))))

--- a/test/cases/expressions/lambda-with-lambda-arg.hack
+++ b/test/cases/expressions/lambda-with-lambda-arg.hack
@@ -1,0 +1,3 @@
+((function(): void) $test): void ==> {
+    
+};

--- a/test/cases/expressions/lambda-with-lambda-arg.hack
+++ b/test/cases/expressions/lambda-with-lambda-arg.hack
@@ -1,3 +1,7 @@
 ((function(): void) $test): void ==> {
     
 };
+
+(  (  function ( ) : void ) $test ) : void ==> {
+    
+};

--- a/test/cases/expressions/lambda-with-lambda-arg.hack
+++ b/test/cases/expressions/lambda-with-lambda-arg.hack
@@ -1,7 +1,13 @@
 ((function(): void) $test): void ==> {
-    
 };
 
-(  (  function ( ) : void ) $test ) : void ==> {
-    
+(  ( /*test*/ function ( ) : void ) $test ) : void ==> {
 };
+
+(  ( function (  )  /*test*/  : void ) $test ) : void ==> {
+};
+
+// TODO: The line below should not error as it is valid Hack.
+//       See PR #8 for details.
+// (  ( function /*test*/ (  )  : void ) $test ) : void ==> {
+// };


### PR DESCRIPTION
# Description

Previously, the grammar incorrectly parsed lambdas when the first arg was a function type. This was a general conflict between parenthesized expressions, lambda expressions, and anonymous expressions (note that lambda and anonymous expressions naturally overlap). This was solved by indirectly editing precedence through concatenating function type arg tokens.

This solution went through many iterations to find one that didn't cause other conflicts.

### Previous test output:
```
(script [0, 0] - [3, 0]
  (expression_statement [0, 0] - [2, 2]
    (parenthesized_expression [0, 0] - [2, 1]
      (lambda_expression [0, 1] - [2, 1]
        (parameters [0, 1] - [0, 26]
          (ERROR [0, 2] - [0, 19]
            (parameters [0, 10] - [0, 12])
            (type_specifier [0, 14] - [0, 18]))
          (parameter [0, 20] - [0, 25]
            name: (variable [0, 20] - [0, 25])))
        return_type: (type_specifier [0, 28] - [0, 32])
        body: (compound_statement [0, 37] - [2, 1])))))
```


# Testing
- [x] Added specific test for error
- [x] Corpus passes overall (no unit test regression)
- [x] Decreased error count in real-life code