### PR TITLE
ts-parse and test-dir QOL improvements

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -10,13 +10,6 @@
     {
       "label": "ts-parse",
       "type": "shell",
-      "command": "F=${file}; npx tree-sitter parse $F>\"${F%.*}.exp\"; code -r \"${F%.*}.exp\"",
-      "detail": "tree-sitter parse ${file}",
-      "problemMatcher": []
-    },
-    {
-      "label": "ts-gen-and-parse",
-      "type": "shell",
       "command": "F=${file}; bin/generate-parser && { npx tree-sitter parse $F>\"${F%.*}.exp\"; code -r \"${F%.*}.exp\"; }",
       "detail": "npx tree-sitter generate && tree-sitter parse ${file}",
       "problemMatcher": []
@@ -24,7 +17,7 @@
     {
       "label": "ts-query",
       "type": "shell",
-      "command": "F=${file}; bin/ts-query $F>\"${F%.*}.exp\" && code -r \"${F%.*}.exp\"",
+      "command": "F=${file}; parsed=$(bin/ts-query $F) && echo \"$parsed\">\"${F%.*}.exp\" && code -r \"${F%.*}.exp\"",
       "detail": "bin/ts-query ${file} (implictly runs `npx tree-sitter generate`)",
       "problemMatcher": []
     },

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -15,10 +15,17 @@
       "problemMatcher": []
     },
     {
+      "label": "ts-gen-and-parse",
+      "type": "shell",
+      "command": "bin/generate-parser && F=${file} && { npx tree-sitter parse $F>\"${F%.*}.exp\"; code -r \"${F%.*}.exp\"; }",
+      "detail": "npx tree-sitter generate && tree-sitter parse ${file}",
+      "problemMatcher": []
+    },
+    {
       "label": "ts-query",
       "type": "shell",
       "command": "F=${file}; bin/ts-query $F>\"${F%.*}.exp\"; code -r \"${F%.*}.exp\"",
-      "detail": "bin/ts-query ${file}",
+      "detail": "bin/ts-query ${file} (implictly runs `npx tree-sitter generate`)",
       "problemMatcher": []
     },
     {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -17,14 +17,14 @@
     {
       "label": "ts-gen-and-parse",
       "type": "shell",
-      "command": "bin/generate-parser && F=${file} && { npx tree-sitter parse $F>\"${F%.*}.exp\"; code -r \"${F%.*}.exp\"; }",
+      "command": "F=${file}; bin/generate-parser && { npx tree-sitter parse $F>\"${F%.*}.exp\"; code -r \"${F%.*}.exp\"; }",
       "detail": "npx tree-sitter generate && tree-sitter parse ${file}",
       "problemMatcher": []
     },
     {
       "label": "ts-query",
       "type": "shell",
-      "command": "F=${file}; bin/ts-query $F>\"${F%.*}.exp\"; code -r \"${F%.*}.exp\"",
+      "command": "F=${file}; bin/ts-query $F>\"${F%.*}.exp\" && code -r \"${F%.*}.exp\"",
       "detail": "bin/ts-query ${file} (implictly runs `npx tree-sitter generate`)",
       "problemMatcher": []
     },

--- a/bin/test-dir
+++ b/bin/test-dir
@@ -4,4 +4,8 @@ set -e
 
 source bin/require_fd
 
-$fd '\.(hack|php)$' "$@" | xargs -r -n 256 bin/ts-errors
+# Note: By default, fd ignores hidden directories,
+#       hidden files, and .gitignore patterns
+# To change this behavior, use --hidden and/or --no-ignore with fd calls
+
+{ fd . -e php "$@" | xargs -r egrep -l "^<\?hh" & fd . -e hack "$@"; } | xargs -r -n 256 bin/ts-errors

--- a/bin/ts-query
+++ b/bin/ts-query
@@ -22,6 +22,4 @@ source bin/require_sed
 #         body: (expression_statement
 #           (integer))))
 
-bin/generate-parser 1>/dev/null
-
-npx tree-sitter parse $@ | $sed -e 's/ \[.*\]//'
+bin/generate-parser 1>/dev/null && { npx tree-sitter parse $@ | $sed -e 's/ \[.*\]//'; }

--- a/bin/ts-query
+++ b/bin/ts-query
@@ -22,4 +22,6 @@ source bin/require_sed
 #         body: (expression_statement
 #           (integer))))
 
-bin/generate-parser 1>/dev/null && { npx tree-sitter parse $@ | $sed -e 's/ \[.*\]//'; }
+bin/generate-parser 1>/dev/null
+
+npx tree-sitter parse $@ | $sed -e 's/ \[.*\]//'


### PR DESCRIPTION
## ts-gen-and-parse

Allows easy task to regen parser before running the normal parse

Test of behavior of mix of `&&` and `{` / `}` in ts-gen-and-parse
- If bin/generate-parser fails, then ts-gen-and-parse fails
- If bin/generate-parser succeeds, then the parse result is output regardless of error status

## test-dir
Makes more specific extension/header checking and adds some helpful info

As desired, test-dir only scans in the left column of valid hack files
![image](https://user-images.githubusercontent.com/42774874/124814402-f31ca900-df33-11eb-9627-5521483fe362.png)



**Happy to hear any feedback on the usefulness/applicability of these because they are definitely personal preferences**

