### PR TITLE
Fix nested as expression in selection expression

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -725,7 +725,7 @@ const rules = {
   selection_expression: $ =>
     prec.select(
       seq(
-        $._variablish,
+        choice($._variablish, $.as_expression),
         field('selection_operator', choice('?->', '->')),
         choice($._variablish, $.braced_expression, alias($._keyword, $.identifier)),
       ),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5404,8 +5404,17 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "SYMBOL",
-            "name": "_variablish"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_variablish"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "as_expression"
+              }
+            ]
           },
           {
             "type": "FIELD",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2576,6 +2576,10 @@
       "required": true,
       "types": [
         {
+          "type": "as_expression",
+          "named": true
+        },
+        {
           "type": "braced_expression",
           "named": true
         },

--- a/test/cases/expressions/selection-with-as.exp
+++ b/test/cases/expressions/selection-with-as.exp
@@ -1,0 +1,42 @@
+(script
+  (expression_statement
+    (selection_expression
+      (as_expression
+        left: (variable)
+        right: (type_specifier))
+      (qualified_identifier
+        (identifier))))
+  (expression_statement
+    (call_expression
+      function: (selection_expression
+        (as_expression
+          left: (variable)
+          right: (type_specifier))
+        (qualified_identifier
+          (identifier)))
+      (arguments)))
+  (expression_statement
+    (selection_expression
+      (parenthesized_expression
+        (as_expression
+          left: (variable)
+          right: (type_specifier)))
+      (qualified_identifier
+        (identifier))))
+  (expression_statement
+    (as_expression
+      left: (selection_expression
+        (variable)
+        (qualified_identifier
+          (identifier)))
+      right: (type_specifier)))
+  (expression_statement
+    (selection_expression
+      (as_expression
+        left: (selection_expression
+          (variable)
+          (qualified_identifier
+            (identifier)))
+        right: (type_specifier))
+      (qualified_identifier
+        (identifier)))))

--- a/test/cases/expressions/selection-with-as.hack
+++ b/test/cases/expressions/selection-with-as.hack
@@ -1,0 +1,9 @@
+$var as nonnull->test;
+
+$var as nonnull->test();
+
+($var as nonnull)->test;
+
+$var->test as nonnull;
+
+$var->test as nonnull->test2;


### PR DESCRIPTION
# Description

All the `MISSING identifier` errors left are caused by lines like `$var as nonnull->getInfo();`. These lines are incorrectly parsed because the precedence of the select `->` is higher than the `as`. In other words, t-s-h is reading the line as `$var as (nonnull->getInfo());`  instead of `($var as nonnull)->getInfo();`.

This doesn’t cause Hack parsing errors but I feel like it should because it violates the precedence here: https://docs.hhvm.com/hack/expressions-and-operators/operator-precedence. Regardless, this an explicit fix for the issue and does _not_ modify precedence.

### Previous test output:
```
$var as nonnull->getInfo();


(script
  (expression_statement
    (binary_expression
      left: (binary_expression
        left: (as_expression
          left: (variable)
          right: (type_specifier))
        right: (qualified_identifier
          (identifier)))
      right: (call_expression
        function: (qualified_identifier
          (identifier))
        (arguments)))))
test.hack		0 ms	(MISSING identifier)

```


# Testing
- [x] Added specific test for error
- [x] Corpus passes overall (no unit test regression)
- [x] Decreased error count in real-life code