### PR TITLE
Add CI testing with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
       - "**"
   push:
     branches:
-      - "master"
       - "main"
 jobs:
   test_ubuntu:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: Build/test
+on:
+  pull_request:
+    branches:
+      - "**"
+  push:
+    branches:
+      - "master"
+      - "main"
+jobs:
+  test_ubuntu:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+      - run: npm install
+      - run: npm test
+  test_macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+      - run: brew install gnu-sed
+      - run: npm install
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "scripts": {
     "build": "bin/generate-parser --force && node-gyp build",
-    "test": "bin/test-corpus && bin/test-examples --count",
+    "test": "bin/generate-corpus && tree-sitter test",
     "test-corpus": "bin/test-corpus",
     "test-examples": "bin/test-examples",
     "reset": "rm -rf build node_modules package-lock.json tmp/grammar.js.sha && npm install && npm run build"


### PR DESCRIPTION
This PR adds CI to the repo through Git Actions. I referenced other tree-sitter-repo's such as 

- https://github.com/tree-sitter/tree-sitter-php
- https://github.com/tree-sitter/tree-sitter-typescript
- https://github.com/tree-sitter/tree-sitter-python

Now after a PR is made or a push is made to main/master, Github will test running `bin/generate-corpus` and `tree-sitter test` on ubuntu and MacOS. Any failing test cases will be reported.