### PR TITLE
Add XHP attribute test

### DIFF
--- a/test/cases/expressions/xhp-attribute.exp
+++ b/test/cases/expressions/xhp-attribute.exp
@@ -14,6 +14,22 @@
                   (string)))))))))
   (expression_statement
     (xhp_expression
+      (xhp_open
+        (xhp_identifier)
+        (xhp_attribute
+          (xhp_identifier)
+          (braced_expression
+            (call_expression
+              function: (qualified_identifier
+                (identifier))
+              (arguments
+                (argument
+                  (string)))))))
+      (xhp_string)
+      (xhp_close
+        (xhp_identifier))))
+  (expression_statement
+    (xhp_expression
       (xhp_open_close
         (xhp_identifier)
         (xhp_attribute

--- a/test/cases/expressions/xhp-attribute.hack
+++ b/test/cases/expressions/xhp-attribute.hack
@@ -1,5 +1,7 @@
 <frag info={get_str('info')} />;
 
+<frag info={get_str('info')}> </frag>;
+
 <test:attribute_types
         mystring="foo"
         mybool={true}


### PR DESCRIPTION
###  Summary

This PR adds a test case for XHP attributes and resolves #20. 

### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/tree-sitter-hack/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).